### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ### Notice: this project is deprecated. Please try my new blog engine [pugo](https://github.com/go-xiaohei/pugo).
 
-#Fxh.Go
+# Fxh.Go
 
 A fast and simple blog engine with [GoInk](https://github.com/fuxiaohei/GoInk) framework in Golang.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
